### PR TITLE
Issue-38 - Compute the total discharge portion if not provided

### DIFF
--- a/src/Flowtracker2Plugin/DataFileParser.cs
+++ b/src/Flowtracker2Plugin/DataFileParser.cs
@@ -141,6 +141,8 @@ namespace FlowTracker2Plugin
                     manualGauging.Verticals.Add(CreateVertical(station, startStation, endStation));
                 }
 
+                AdjustUnknownTotalDischargePortion(manualGauging);
+
                 _resultsAppender.AddDischargeActivity(visit, dischargeActivity);
 
                 AddTemperatureReadings(visit);
@@ -364,6 +366,19 @@ namespace FlowTracker2Plugin
             }
 
             return vertical;
+        }
+
+        private void AdjustUnknownTotalDischargePortion(ManualGaugingDischargeSection manualGauging)
+        {
+            var totalDischarge = manualGauging.Discharge.Value;
+
+            foreach (var vertical in manualGauging.Verticals)
+            {
+                if (!double.IsNaN(vertical.Segment.TotalDischargePortion) || double.IsNaN(vertical.Segment.Discharge))
+                    continue;
+
+                vertical.Segment.TotalDischargePortion = 100 * vertical.Segment.Discharge / totalDischarge;
+            }
         }
 
         private MeasurementConditionData CreateMeasurementCondition(Station station)


### PR DESCRIPTION
Sometimes the Stations[i].Calculations.FractionOfTotalDischarge value is a NaN, not actually stored withing the FlowTracker2 file.

When that occurs, compute the portion on the fly.

So if the FlowTracker2 tells us a portion, we use it. Otherwise the plugin will do the math.