### PR TITLE
Issue-42 - Add implicit vertical number

### DIFF
--- a/src/Flowtracker2Plugin/DataFileParser.cs
+++ b/src/Flowtracker2Plugin/DataFileParser.cs
@@ -138,7 +138,7 @@ namespace FlowTracker2Plugin
 
                 foreach (var station in DataFile.Stations)
                 {
-                    manualGauging.Verticals.Add(CreateVertical(station, startStation, endStation));
+                    manualGauging.Verticals.Add(CreateVertical(manualGauging.Verticals.Count, station, startStation, endStation));
                 }
 
                 AdjustUnknownTotalDischargePortion(manualGauging);
@@ -306,7 +306,7 @@ namespace FlowTracker2Plugin
             throw new ArgumentException($"DischargeEquation='{dischargeEquation}' is not supported");
         }
 
-        private Vertical CreateVertical(Station station, Station startStation, Station endStation)
+        private Vertical CreateVertical(int sequenceNumber, Station station, Station startStation, Station endStation)
         {
             var verticalType = station == startStation && ValidBankTypes.Contains(station.StationType)
                 ? VerticalType.StartEdgeNoWaterBefore
@@ -316,6 +316,7 @@ namespace FlowTracker2Plugin
 
             var vertical = new Vertical
             {
+                SequenceNumber = sequenceNumber,
                 TaglinePosition = UnitConverter.ConvertDistance(station.Location),
                 Comments = station.Comment,
                 MeasurementTime = station.CreationTime,


### PR DESCRIPTION
FlowTracker2 files don't have an explicit station number, but the FlowTracker2 visualization software implicitly counts
the verticals starting at 0.

Use the same logic in the plugin, so that all the AQTS verticals match the station # shown in the SonTek software.