### PR TITLE
PF-991 - Update the log4net dependency on the converter tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It is recommended that you use the most recent version of the plugin which match
 
 | AQTS Version | Latest compatible plugin Version |
 | --- | --- |
-| AQTS 2019.2+ | [v19.2.10](https://github.com/AquaticInformatics/flowtracker2-field-data-plugin/releases/download/v19.2.10/FlowTracker2Plugin.plugin) - Adds incrementing vertical numbers |
+| AQTS 2019.2+ | [v19.2.12](https://github.com/AquaticInformatics/flowtracker2-field-data-plugin/releases/download/v19.2.12/FlowTracker2Plugin.plugin) - Adds incrementing vertical numbers |
 | 2017.4 - 2019.1 | [v17.4.44](https://github.com/AquaticInformatics/flowtracker2-field-data-plugin/releases/download/v17.4.44/FlowTracker2Plugin.plugin) |
 
 ## Requirements for building the plugin from source
@@ -52,4 +52,4 @@ See the [PluginTester](https://github.com/AquaticInformatics/aquarius-field-data
 
 ## Installation of the plugin
 
-Use the [FieldDataPluginTool](https://github.com/AquaticInformatics/aquarius-field-data-framework/tree/master/src/FieldDataPluginTool) to install the plugin on your AQTS app server.
+Use the SystemConfig page to install/enable this plugin on your AQTS app server.

--- a/src/FlowTracker2Converter/FlowTracker2Converter.csproj
+++ b/src/FlowTracker2Converter/FlowTracker2Converter.csproj
@@ -44,8 +44,8 @@
     <Reference Include="ICSharpCode.SharpZipLib">
       <HintPath>..\External\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
-    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -55,8 +55,10 @@
       <HintPath>..\External\SonTek.StandaloneDataParser.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/src/FlowTracker2Converter/packages.config
+++ b/src/FlowTracker2Converter/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Costura.Fody" version="1.6.2" targetFramework="net47" developmentDependency="true" />
   <package id="Fody" version="2.0.0" targetFramework="net47" developmentDependency="true" />
-  <package id="log4net" version="2.0.8" targetFramework="net47" />
+  <package id="log4net" version="2.0.12" targetFramework="net47" />
 </packages>


### PR DESCRIPTION
The FlowTracker2Converter.exe tool was not affected by the log4net vulnerability, but the newer log4net dependency was updated anyways.