### PR TITLE
PF-1218 - When the ISO uncertainty is scaled, add a QA comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It is recommended that you use the most recent version of the plugin which match
 
 | AQTS Version | Latest compatible plugin Version |
 | --- | --- |
-| AQTS 2020.2+ | [v20.2.0](https://github.com/AquaticInformatics/flowtracker2-field-data-plugin/releases/download/v20.2.0/FlowTracker2Plugin.plugin) - Adds configurable ISO Uncertainty Scalar |
+| AQTS 2020.2+ | [v20.2.1](https://github.com/AquaticInformatics/flowtracker2-field-data-plugin/releases/download/v20.2.1/FlowTracker2Plugin.plugin) - Adds configurable ISO Uncertainty Scalar |
 | AQTS 2019.2 - 2020.1 | [v19.2.13](https://github.com/AquaticInformatics/flowtracker2-field-data-plugin/releases/download/v19.2.13/FlowTracker2Plugin.plugin) - Adds Party and Primary Meter to channel measurement<br/>v19.2.12 - Adds incrementing vertical numbers |
 | 2017.4 - 2019.1 | [v17.4.44](https://github.com/AquaticInformatics/flowtracker2-field-data-plugin/releases/download/v17.4.44/FlowTracker2Plugin.plugin) |
 

--- a/src/Flowtracker2Plugin/DataFileParser.cs
+++ b/src/Flowtracker2Plugin/DataFileParser.cs
@@ -235,6 +235,12 @@ namespace FlowTracker2Plugin
 
             dischargeActivity.QuantitativeUncertainty = scalar * DataFile.Calculations.UncertaintyIso.Overall * 100;
 
+            // ReSharper disable once CompareOfFloatsByEqualityOperator
+            if (scalar != 1.0)
+            {
+                dischargeActivity.QualityAssuranceComments = $"Scaled ISO uncertainty by {scalar}";
+            }
+
             return dischargeActivity;
         }
 


### PR DESCRIPTION
This will help track which measurements were adjusted from their default 68% confidence interval.