### PR TITLE
Feature/at 2451 dual target net10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 # Skip the deploy folder
 deploy/
 
+# Fody auto-generates this XML-schema file next to FodyWeavers.xml on every build (for IntelliSense)
+FodyWeavers.xsd
+
 # User-specific files
 *.suo
 *.user

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,11 @@ artifacts:
     name: ThePlugin
     type: file
 
-  - path: src\FlowTracker2Converter\bin\Release\FlowTracker2Converter.exe
+  - path: src\FlowTracker2Plugin\deploy\Release\FlowTracker2Plugin-net10.plugin
+    name: ThePlugin-net10
+    type: file
+
+  - path: src\FlowTracker2Converter\bin\Release\net472\FlowTracker2Converter.exe
     name: TheConverter
     type: file
 
@@ -46,7 +50,7 @@ deploy:
     tag: v$(APPVEYOR_BUILD_VERSION)
     release: FlowTracker2 plugin $(APPVEYOR_BUILD_VERSION)
     description: ''
-    artifact: ThePlugin, TheConverter
+    artifact: ThePlugin, ThePlugin-net10, TheConverter
     auth_token: $(GITHUB_AUTH_TOKEN)
     on:
       is_not_pr: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2017
+image: Visual Studio 2026
 
 platform: Any CPU
 configuration: Release

--- a/src/FlowTracker2Converter/FlowTracker2Converter.csproj
+++ b/src/FlowTracker2Converter/FlowTracker2Converter.csproj
@@ -1,127 +1,45 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{647B46C2-0116-4945-859F-DE1D61B46067}</ProjectGuid>
     <OutputType>WinExe</OutputType>
-    <RootNamespace>FlowTracker2Converter</RootNamespace>
+    <TargetFramework>net472</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
     <AssemblyName>FlowTracker2Converter</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup>
+    <RootNamespace>FlowTracker2Converter</RootNamespace>
     <ApplicationIcon>TimeSeries.ico</ApplicationIcon>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <Deterministic>true</Deterministic>
   </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="Costura, Version=1.6.2.0, Culture=neutral, PublicKeyToken=9919ef960d84173d, processorArchitecture=MSIL">
-      <HintPath>..\packages\Costura.Fody.1.6.2\lib\dotnet\Costura.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
+    <Reference Include="System.Configuration" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="ICSharpCode.SharpZipLib">
       <HintPath>..\External\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
-    <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Newtonsoft.Json">
       <HintPath>..\External\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="SonTek.StandaloneDataParser">
       <HintPath>..\External\SonTek.StandaloneDataParser.dll</HintPath>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
+
   <ItemGroup>
-    <Compile Include="ExpectedException.cs" />
-    <Compile Include="MainForm.cs">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Include="MainForm.Designer.cs">
-      <DependentUpon>MainForm.cs</DependentUpon>
-    </Compile>
-    <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="TextTable.cs" />
-    <EmbeddedResource Include="MainForm.resx">
-      <DependentUpon>MainForm.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <EmbeddedResource Include="log4net.config" />
-    <None Include="License.md" />
-    <None Include="packages.config" />
-    <None Include="Properties\Settings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
+    <PackageReference Include="log4net" Version="2.0.12" />
+    <PackageReference Include="Fody" Version="6.9.3" PrivateAssets="all" />
+    <PackageReference Include="Costura.Fody" Version="6.2.0" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\External\SonTek.StandaloneDataParser.License.rtf">
+      <Link>SonTek.StandaloneDataParser.License.rtf</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <Compile Include="Properties\Settings.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Settings.settings</DependentUpon>
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-    </Compile>
-    <None Include="Readme.md" />
   </ItemGroup>
+
   <ItemGroup>
-    <None Include="App.config" />
+    <ProjectReference Include="..\UnitConversion\UnitConversion.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="FodyWeavers.xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="TimeSeries.ico" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\UnitConversion\UnitConversion.csproj">
-      <Project>{2dfac616-287f-4cb3-ac06-98bca606bc56}</Project>
-      <Name>UnitConversion</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Fody.2.0.0\build\netstandard1.4\Fody.targets" Condition="Exists('..\packages\Fody.2.0.0\build\netstandard1.4\Fody.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Fody.2.0.0\build\netstandard1.4\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.2.0.0\build\netstandard1.4\Fody.targets'))" />
-    <Error Condition="!Exists('..\packages\Costura.Fody.1.6.2\build\dotnet\Costura.Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.1.6.2\build\dotnet\Costura.Fody.targets'))" />
-  </Target>
-  <Import Project="..\packages\Costura.Fody.1.6.2\build\dotnet\Costura.Fody.targets" Condition="Exists('..\packages\Costura.Fody.1.6.2\build\dotnet\Costura.Fody.targets')" />
 </Project>

--- a/src/FlowTracker2Converter/FlowTracker2Converter.csproj
+++ b/src/FlowTracker2Converter/FlowTracker2Converter.csproj
@@ -33,6 +33,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="log4net.config" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="..\External\SonTek.StandaloneDataParser.License.rtf">
       <Link>SonTek.StandaloneDataParser.License.rtf</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/FlowTracker2Converter/FlowTracker2Converter.csproj
+++ b/src/FlowTracker2Converter/FlowTracker2Converter.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.12" />
+    <PackageReference Include="log4net" Version="3.3.2" />
     <PackageReference Include="Fody" Version="6.9.3" PrivateAssets="all" />
     <PackageReference Include="Costura.Fody" Version="6.2.0" PrivateAssets="all" />
   </ItemGroup>

--- a/src/FlowTracker2Converter/FodyWeavers.xml
+++ b/src/FlowTracker2Converter/FodyWeavers.xml
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Weavers>
+<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
   <Costura />
 </Weavers>

--- a/src/FlowTracker2Converter/packages.config
+++ b/src/FlowTracker2Converter/packages.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Costura.Fody" version="1.6.2" targetFramework="net47" developmentDependency="true" />
-  <package id="Fody" version="2.0.0" targetFramework="net47" developmentDependency="true" />
-  <package id="log4net" version="2.0.12" targetFramework="net47" />
-</packages>

--- a/src/Flowtracker2Plugin/FlowTracker2Plugin.csproj
+++ b/src/Flowtracker2Plugin/FlowTracker2Plugin.csproj
@@ -9,6 +9,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <!-- NU1702: FieldDataPluginFramework.dll is a net472-only assembly referenced directly during migration — expected and acceptable -->
     <NoWarn>$(NoWarn);NU1702</NoWarn>
+    <AquariusFieldDataFrameworkVersion>20.2.5</AquariusFieldDataFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
@@ -19,10 +20,15 @@
 	  <!-- 'Private' needed for net10 - FieldDataPluginFramework already loaded into the Default
          AssemblyLoadContext, a second reference fails with an InvalidCastException. -->
     <Reference Include="FieldDataPluginFramework" Condition="'$(TargetFramework)' == 'net10.0'">
-      <HintPath>$(NuGetPackageRoot)\aquarius.fielddataframework\20.2.5\lib\net472\FieldDataPluginFramework.dll</HintPath>
+      <HintPath>$(NuGetPackageRoot)\aquarius.fielddataframework\$(AquariusFieldDataFrameworkVersion)\lib\net472\FieldDataPluginFramework.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <PackageReference Include="Aquarius.FieldDataFramework" Version="20.2.5" Condition="'$(TargetFramework)' == 'net472'" />
+    <PackageReference Include="Aquarius.FieldDataFramework" Version="$(AquariusFieldDataFrameworkVersion)" Condition="'$(TargetFramework)' == 'net472'" />
+    <!-- net10.0 can't PackageReference this net472-only package for compile/runtime (NU1202), but still needs it
+         restored into the global packages folder so the HintPath/tool paths above resolve when building
+         `-f net10.0` alone (a prior net472 build/restore may not have happened yet in that scenario).
+         ExcludeAssets="all" forces the restore without pulling in any compile/runtime/build assets. -->
+    <PackageReference Include="Aquarius.FieldDataFramework" Version="$(AquariusFieldDataFrameworkVersion)" Condition="'$(TargetFramework)' == 'net10.0'" ExcludeAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
@@ -54,12 +60,12 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <PluginPackagerExe Condition="'$(TargetFramework)' == 'net472'">$(NuGetPackageRoot)\aquarius.fielddataframework\20.2.5\tools\PluginPackager.exe</PluginPackagerExe>
+    <PluginPackagerExe Condition="'$(TargetFramework)' == 'net472'">$(NuGetPackageRoot)\aquarius.fielddataframework\$(AquariusFieldDataFrameworkVersion)\tools\PluginPackager.exe</PluginPackagerExe>
     <!-- TODO: once Aquarius.FieldDataFramework ships a dual-targeted (net472+net10.0) NuGet package,
          this net10.0 path should point at the real published tools\net10.0 folder instead of a manually-copied local one. -->
-    <PluginPackagerExe Condition="'$(TargetFramework)' == 'net10.0'">$(NuGetPackageRoot)\aquarius.fielddataframework\20.2.5\tools\net10.0\PluginPackager.exe</PluginPackagerExe>
-    <PluginTesterExe Condition="'$(TargetFramework)' == 'net472'">$(NuGetPackageRoot)\aquarius.fielddataframework\20.2.5\tools\PluginTester.exe</PluginTesterExe>
-    <PluginTesterExe Condition="'$(TargetFramework)' == 'net10.0'">$(NuGetPackageRoot)\aquarius.fielddataframework\20.2.5\tools\net10.0\PluginTester.exe</PluginTesterExe>
+    <PluginPackagerExe Condition="'$(TargetFramework)' == 'net10.0'">$(NuGetPackageRoot)\aquarius.fielddataframework\$(AquariusFieldDataFrameworkVersion)\tools\net10.0\PluginPackager.exe</PluginPackagerExe>
+    <PluginTesterExe Condition="'$(TargetFramework)' == 'net472'">$(NuGetPackageRoot)\aquarius.fielddataframework\$(AquariusFieldDataFrameworkVersion)\tools\PluginTester.exe</PluginTesterExe>
+    <PluginTesterExe Condition="'$(TargetFramework)' == 'net10.0'">$(NuGetPackageRoot)\aquarius.fielddataframework\$(AquariusFieldDataFrameworkVersion)\tools\net10.0\PluginTester.exe</PluginTesterExe>
     <PackagedPluginName Condition="'$(TargetFramework)' == 'net472'">$(AssemblyName).plugin</PackagedPluginName>
     <PackagedPluginName Condition="'$(TargetFramework)' == 'net10.0'">$(AssemblyName)-net10.plugin</PackagedPluginName>
   </PropertyGroup>
@@ -69,3 +75,4 @@
     <Exec Command="&quot;$(PluginTesterExe)&quot; /Plugin=&quot;$(TargetPath)&quot; /Data=&quot;$(SolutionDir)..\data\DemoData.ft&quot;" />
   </Target>
 </Project>
+

--- a/src/Flowtracker2Plugin/FlowTracker2Plugin.csproj
+++ b/src/Flowtracker2Plugin/FlowTracker2Plugin.csproj
@@ -55,17 +55,18 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <PluginPackagerExe Condition="'$(TargetFramework)' == 'net472'">$(NuGetPackageRoot)\aquarius.fielddataframework\$(AquariusFieldDataFrameworkVersion)\tools\PluginPackager.exe</PluginPackagerExe>
+    <!-- tools\ (net472) vs tools\net10.0\ (net10.0) — asymmetric layout in the NuGet package itself. -->
+    <AquariusToolsSubfolder Condition="'$(TargetFramework)' == 'net10.0'">net10.0\</AquariusToolsSubfolder>
     <!-- TODO: once Aquarius.FieldDataFramework ships a dual-targeted (net472+net10.0) NuGet package,
-         this net10.0 path should point at the real published tools\net10.0 folder instead of a manually-copied local one. -->
-    <PluginPackagerExe Condition="'$(TargetFramework)' == 'net10.0'">$(NuGetPackageRoot)\aquarius.fielddataframework\$(AquariusFieldDataFrameworkVersion)\tools\net10.0\PluginPackager.exe</PluginPackagerExe>
-    <PluginTesterExe Condition="'$(TargetFramework)' == 'net472'">$(NuGetPackageRoot)\aquarius.fielddataframework\$(AquariusFieldDataFrameworkVersion)\tools\PluginTester.exe</PluginTesterExe>
-    <PluginTesterExe Condition="'$(TargetFramework)' == 'net10.0'">$(NuGetPackageRoot)\aquarius.fielddataframework\$(AquariusFieldDataFrameworkVersion)\tools\net10.0\PluginTester.exe</PluginTesterExe>
+         the net10.0 path should point at the real published tools\net10.0 folder instead of a manually-copied local one. -->
+    <PluginPackagerExe>$(NuGetPackageRoot)\aquarius.fielddataframework\$(AquariusFieldDataFrameworkVersion)\tools\$(AquariusToolsSubfolder)PluginPackager.exe</PluginPackagerExe>
+    <PluginTesterExe>$(NuGetPackageRoot)\aquarius.fielddataframework\$(AquariusFieldDataFrameworkVersion)\tools\$(AquariusToolsSubfolder)PluginTester.exe</PluginTesterExe>
     <PackagedPluginName Condition="'$(TargetFramework)' == 'net472'">$(AssemblyName).plugin</PackagedPluginName>
     <PackagedPluginName Condition="'$(TargetFramework)' == 'net10.0'">$(AssemblyName)-net10.plugin</PackagedPluginName>
   </PropertyGroup>
 
-  <Target Name="PackageAndTestPlugin" AfterTargets="Build" Condition="Exists('$(PluginPackagerExe)') And Exists('$(PluginTesterExe)')">
+  <!-- '$(TargetFramework)' != '' guards against the outer multi-targeting dispatch build running with an empty $(TargetPath). -->
+  <Target Name="PackageAndTestPlugin" AfterTargets="Build" Condition="'$(TargetFramework)' != '' And Exists('$(PluginPackagerExe)') And Exists('$(PluginTesterExe)')">
     <Exec Command="&quot;$(PluginPackagerExe)&quot; &quot;$(TargetPath)&quot; /OutputPath=&quot;$(ProjectDir)deploy\$(Configuration)\$(PackagedPluginName)&quot;" />
     <Exec Command="&quot;$(PluginTesterExe)&quot; /Plugin=&quot;$(TargetPath)&quot; /Data=&quot;$(MSBuildProjectDirectory)\..\..\data\DemoData.ft&quot;" />
   </Target>

--- a/src/Flowtracker2Plugin/FlowTracker2Plugin.csproj
+++ b/src/Flowtracker2Plugin/FlowTracker2Plugin.csproj
@@ -1,75 +1,71 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{D0366373-258D-481C-BCF6-4BF534493B1B}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>FlowTracker2Plugin</RootNamespace>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <AssemblyName>FlowTracker2Plugin</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <RootNamespace>FlowTracker2Plugin</RootNamespace>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <Deterministic>true</Deterministic>
     <PlatformTarget>x64</PlatformTarget>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!-- NU1702: FieldDataPluginFramework.dll is a net472-only assembly referenced directly during migration — expected and acceptable -->
+    <NoWarn>$(NoWarn);NU1702</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="FieldDataPluginFramework, Version=2.9.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\Aquarius.FieldDataFramework.20.2.5\lib\net472\FieldDataPluginFramework.dll</HintPath>
+	  <!-- 'Private' needed for net10 - FieldDataPluginFramework already loaded into the Default
+         AssemblyLoadContext, a second reference fails with an InvalidCastException. -->
+    <Reference Include="FieldDataPluginFramework" Condition="'$(TargetFramework)' == 'net10.0'">
+      <HintPath>$(NuGetPackageRoot)\aquarius.fielddataframework\20.2.5\lib\net472\FieldDataPluginFramework.dll</HintPath>
+      <Private>false</Private>
     </Reference>
-    <Reference Include="ICSharpCode.SharpZipLib, Version=0.85.5.452, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <PackageReference Include="Aquarius.FieldDataFramework" Version="20.2.5" Condition="'$(TargetFramework)' == 'net472'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Required for SharpZipLib on net10.0 -->
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="ICSharpCode.SharpZipLib">
       <HintPath>..\External\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Newtonsoft.Json">
       <HintPath>..\External\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="SonTek.StandaloneDataParser">
       <HintPath>..\External\SonTek.StandaloneDataParser.dll</HintPath>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="DataFileParser.cs" />
-    <Compile Include="Plugin.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
+
   <ItemGroup>
     <None Include="..\External\SonTek.StandaloneDataParser.License.rtf">
       <Link>SonTek.StandaloneDataParser.License.rtf</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="packages.config" />
   </ItemGroup>
+
   <ItemGroup>
-    <ProjectReference Include="..\UnitConversion\UnitConversion.csproj">
-      <Project>{2dfac616-287f-4cb3-ac06-98bca606bc56}</Project>
-      <Name>UnitConversion</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\UnitConversion\UnitConversion.csproj" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+
   <PropertyGroup>
-    <PostBuildEvent>$(SolutionDir)packages\Aquarius.FieldDataFramework.20.2.5\tools\PluginPackager.exe $(TargetPath) /OutputPath=$(ProjectDir)deploy\$(Configuration)\$(TargetName).plugin
-$(SolutionDir)packages\Aquarius.FieldDataFramework.20.2.5\tools\PluginTester.exe /Plugin=$(TargetPath) /Data=$(SolutionDir)..\data\DemoData.ft</PostBuildEvent>
+    <PluginPackagerExe Condition="'$(TargetFramework)' == 'net472'">$(NuGetPackageRoot)\aquarius.fielddataframework\20.2.5\tools\PluginPackager.exe</PluginPackagerExe>
+    <!-- TODO: once Aquarius.FieldDataFramework ships a dual-targeted (net472+net10.0) NuGet package,
+         this net10.0 path should point at the real published tools\net10.0 folder instead of a manually-copied local one. -->
+    <PluginPackagerExe Condition="'$(TargetFramework)' == 'net10.0'">$(NuGetPackageRoot)\aquarius.fielddataframework\20.2.5\tools\net10.0\PluginPackager.exe</PluginPackagerExe>
+    <PluginTesterExe Condition="'$(TargetFramework)' == 'net472'">$(NuGetPackageRoot)\aquarius.fielddataframework\20.2.5\tools\PluginTester.exe</PluginTesterExe>
+    <PluginTesterExe Condition="'$(TargetFramework)' == 'net10.0'">$(NuGetPackageRoot)\aquarius.fielddataframework\20.2.5\tools\net10.0\PluginTester.exe</PluginTesterExe>
+    <PackagedPluginName Condition="'$(TargetFramework)' == 'net472'">$(AssemblyName).plugin</PackagedPluginName>
+    <PackagedPluginName Condition="'$(TargetFramework)' == 'net10.0'">$(AssemblyName)-net10.plugin</PackagedPluginName>
   </PropertyGroup>
+
+  <Target Name="PackageAndTestPlugin" AfterTargets="Build" Condition="Exists('$(PluginPackagerExe)') And Exists('$(PluginTesterExe)')">
+    <Exec Command="&quot;$(PluginPackagerExe)&quot; &quot;$(TargetPath)&quot; /OutputPath=&quot;$(ProjectDir)deploy\$(Configuration)\$(PackagedPluginName)&quot;" />
+    <Exec Command="&quot;$(PluginTesterExe)&quot; /Plugin=&quot;$(TargetPath)&quot; /Data=&quot;$(SolutionDir)..\data\DemoData.ft&quot;" />
+  </Target>
 </Project>

--- a/src/Flowtracker2Plugin/FlowTracker2Plugin.csproj
+++ b/src/Flowtracker2Plugin/FlowTracker2Plugin.csproj
@@ -7,9 +7,11 @@
     <Deterministic>true</Deterministic>
     <PlatformTarget>x64</PlatformTarget>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <!-- NU1702: FieldDataPluginFramework.dll is a net472-only assembly referenced directly during migration — expected and acceptable -->
+    <!-- NU1702: NuGet resolves against the framework's stated lib\net10.0 (there isn't a
+         separate exact-match asset), which is expected here — the same net472 binary is
+         republished under lib\net10.0 since it loads fine in .NET 10. -->
     <NoWarn>$(NoWarn);NU1702</NoWarn>
-    <AquariusFieldDataFrameworkVersion>26.3.2</AquariusFieldDataFrameworkVersion>
+    <AquariusFieldDataFrameworkVersion>26.3.3</AquariusFieldDataFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
@@ -17,19 +19,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <!-- 'Private' needed for net10 - FieldDataPluginFramework already loaded into the Default
-         AssemblyLoadContext, a second reference fails with an InvalidCastException. -->
-    <Reference Include="FieldDataPluginFramework" Condition="'$(TargetFramework)' == 'net10.0'">
-      <HintPath>$(NuGetPackageRoot)\aquarius.fielddataframework\$(AquariusFieldDataFrameworkVersion)\lib\net472\FieldDataPluginFramework.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
     <PackageReference Include="Aquarius.FieldDataFramework" Version="$(AquariusFieldDataFrameworkVersion)" Condition="'$(TargetFramework)' == 'net472'" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <!-- Forces restore of the net10-only global-packages folder copy the HintPath above
-         depends on, without contributing compile/runtime assets for this TFM. -->
-    <PackageReference Include="Aquarius.FieldDataFramework" Version="$(AquariusFieldDataFrameworkVersion)" ExcludeAssets="all" GeneratePathProperty="true" />
+    <!-- ExcludeAssets="runtime" keeps this a compile-time-only reference for net10.0 — the
+         framework dll is already loaded into the Default AssemblyLoadContext by the host;
+         copying a second private copy to bin\ causes an InvalidCastException. -->
+    <PackageReference Include="Aquarius.FieldDataFramework" Version="$(AquariusFieldDataFrameworkVersion)" ExcludeAssets="runtime" Condition="'$(TargetFramework)' == 'net10.0'" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
@@ -61,12 +55,8 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <!-- tools\ (net472) vs tools\net10.0\ (net10.0) — asymmetric layout in the NuGet package itself. -->
-    <AquariusToolsSubfolder Condition="'$(TargetFramework)' == 'net10.0'">net10.0\</AquariusToolsSubfolder>
-    <!-- TODO: once Aquarius.FieldDataFramework ships a dual-targeted (net472+net10.0) NuGet package,
-         the net10.0 path should point at the real published tools\net10.0 folder instead of a manually-copied local one. -->
-    <PluginPackagerExe>$(NuGetPackageRoot)\aquarius.fielddataframework\$(AquariusFieldDataFrameworkVersion)\tools\$(AquariusToolsSubfolder)PluginPackager.exe</PluginPackagerExe>
-    <PluginTesterExe>$(NuGetPackageRoot)\aquarius.fielddataframework\$(AquariusFieldDataFrameworkVersion)\tools\$(AquariusToolsSubfolder)PluginTester.exe</PluginTesterExe>
+    <PluginPackagerExe>$(NuGetPackageRoot)\aquarius.fielddataframework\$(AquariusFieldDataFrameworkVersion)\tools\$(TargetFramework)\PluginPackager.exe</PluginPackagerExe>
+    <PluginTesterExe>$(NuGetPackageRoot)\aquarius.fielddataframework\$(AquariusFieldDataFrameworkVersion)\tools\$(TargetFramework)\PluginTester.exe</PluginTesterExe>
     <PackagedPluginName Condition="'$(TargetFramework)' == 'net472'">$(AssemblyName).plugin</PackagedPluginName>
     <PackagedPluginName Condition="'$(TargetFramework)' == 'net10.0'">$(AssemblyName)-net10.plugin</PackagedPluginName>
   </PropertyGroup>

--- a/src/Flowtracker2Plugin/FlowTracker2Plugin.csproj
+++ b/src/Flowtracker2Plugin/FlowTracker2Plugin.csproj
@@ -24,11 +24,6 @@
       <Private>false</Private>
     </Reference>
     <PackageReference Include="Aquarius.FieldDataFramework" Version="$(AquariusFieldDataFrameworkVersion)" Condition="'$(TargetFramework)' == 'net472'" />
-    <!-- net10.0 can't PackageReference this net472-only package for compile/runtime (NU1202), but still needs it
-         restored into the global packages folder so the HintPath/tool paths above resolve when building
-         `-f net10.0` alone (a prior net472 build/restore may not have happened yet in that scenario).
-         ExcludeAssets="all" forces the restore without pulling in any compile/runtime/build assets. -->
-    <PackageReference Include="Aquarius.FieldDataFramework" Version="$(AquariusFieldDataFrameworkVersion)" Condition="'$(TargetFramework)' == 'net10.0'" ExcludeAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
@@ -72,7 +67,7 @@
 
   <Target Name="PackageAndTestPlugin" AfterTargets="Build" Condition="Exists('$(PluginPackagerExe)') And Exists('$(PluginTesterExe)')">
     <Exec Command="&quot;$(PluginPackagerExe)&quot; &quot;$(TargetPath)&quot; /OutputPath=&quot;$(ProjectDir)deploy\$(Configuration)\$(PackagedPluginName)&quot;" />
-    <Exec Command="&quot;$(PluginTesterExe)&quot; /Plugin=&quot;$(TargetPath)&quot; /Data=&quot;$(SolutionDir)..\data\DemoData.ft&quot;" />
+    <Exec Command="&quot;$(PluginTesterExe)&quot; /Plugin=&quot;$(TargetPath)&quot; /Data=&quot;$(MSBuildProjectDirectory)\..\..\data\DemoData.ft&quot;" />
   </Target>
 </Project>
 

--- a/src/Flowtracker2Plugin/FlowTracker2Plugin.csproj
+++ b/src/Flowtracker2Plugin/FlowTracker2Plugin.csproj
@@ -25,8 +25,8 @@
     <PackageReference Include="Aquarius.FieldDataFramework" Version="20.2.5" Condition="'$(TargetFramework)' == 'net472'" />
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- Required for SharpZipLib on net10.0 -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <!-- Required for SharpZipLib on net472;-->
     <PackageReference Include="System.Text.Encoding.CodePages" Version="9.0.0" />
   </ItemGroup>
 

--- a/src/Flowtracker2Plugin/FlowTracker2Plugin.csproj
+++ b/src/Flowtracker2Plugin/FlowTracker2Plugin.csproj
@@ -9,7 +9,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <!-- NU1702: FieldDataPluginFramework.dll is a net472-only assembly referenced directly during migration — expected and acceptable -->
     <NoWarn>$(NoWarn);NU1702</NoWarn>
-    <AquariusFieldDataFrameworkVersion>20.2.5</AquariusFieldDataFrameworkVersion>
+    <AquariusFieldDataFrameworkVersion>26.3.2</AquariusFieldDataFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
@@ -24,6 +24,12 @@
       <Private>false</Private>
     </Reference>
     <PackageReference Include="Aquarius.FieldDataFramework" Version="$(AquariusFieldDataFrameworkVersion)" Condition="'$(TargetFramework)' == 'net472'" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <!-- Forces restore of the net10-only global-packages folder copy the HintPath above
+         depends on, without contributing compile/runtime assets for this TFM. -->
+    <PackageReference Include="Aquarius.FieldDataFramework" Version="$(AquariusFieldDataFrameworkVersion)" ExcludeAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/src/Flowtracker2Plugin/Plugin.cs
+++ b/src/Flowtracker2Plugin/Plugin.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+using System;
+using System.IO;
+using System.Text;
 using FieldDataPluginFramework;
 using FieldDataPluginFramework.Context;
 using FieldDataPluginFramework.Results;
@@ -7,6 +9,16 @@ namespace FlowTracker2Plugin
 {
     public class Plugin : IFieldDataPlugin
     {
+        static Plugin()
+        {
+            // Included to avoid "System.NotSupportedException: No data is available for encoding 437." error in net10
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+            // SonTek's DataFileComplete method can cause an "AssemblyLoadContext is unloading or was already unloaded" error in net10
+            // Keeps the UnitConverter type alive to avoid this error
+            GC.KeepAlive(typeof(UnitConversion.UnitConverter));
+        }
+
         public ParseFileResult ParseFile(Stream fileStream, IFieldDataResultsAppender fieldDataResultsAppender, ILog logger)
         {
             var parser = new DataFileParser(logger, fieldDataResultsAppender);

--- a/src/Flowtracker2Plugin/packages.config
+++ b/src/Flowtracker2Plugin/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Aquarius.FieldDataFramework" version="20.2.5" targetFramework="net472" />
-</packages>

--- a/src/UnitConversion/UnitConversion.csproj
+++ b/src/UnitConversion/UnitConversion.csproj
@@ -1,47 +1,24 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{2DFAC616-287F-4CB3-AC06-98BCA606BC56}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>UnitConversion</RootNamespace>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <AssemblyName>UnitConversion</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <RootNamespace>UnitConversion</RootNamespace>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <Deterministic>true</Deterministic>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
+
+  <!-- Microsoft.CSharp, System.Configuration, System.Data(.DataSetExtensions), System.Net.Http, System.Xml(.Linq) are inbox on net10.0 -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="UnitConverter.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
@AquaticInformatics/artemis @AquaticInformatics/nautilus 

Switching the project to SDK-style, and dual-targeting to net10. Changes include

- updating the appveyor image to 2026, allowing net10
- added two lines to Plugin.cs to handle net10-specific exceptions. 
- adds PluginPackagerExe and PluginTesterExe for the net10 build. This doesn't exist yet in aquarius-field-data-framework https://github.com/AquaticInformatics/aquarius-field-data-framework/pull/199- until it does this will remain a draft. The references here to tools\net10.0 were used for testing locally and will be updated once the main framework is merged.